### PR TITLE
Add support for go and java

### DIFF
--- a/example/etc/a_plus_b.go
+++ b/example/etc/a_plus_b.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+func main() {
+	var a int64
+	var b int64
+	fmt.Scanf("%d%d", &a, &b)
+	fmt.Println(a + b)
+}

--- a/example/etc/a_plus_b.java
+++ b/example/etc/a_plus_b.java
@@ -1,0 +1,7 @@
+import java.util.Scanner;
+public class a_plus_b {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        System.out.println(sc.nextLong() + sc.nextLong());
+    }
+}

--- a/example/etc/log_mle.txt
+++ b/example/etc/log_mle.txt
@@ -1,0 +1,10 @@
+time:0.090
+time-wall:0.161
+max-rss:33588
+csw-voluntary:4
+csw-forced:219
+cg-mem:1000
+cg-oom-killed:1
+exitsig:9
+status:SG
+message:Caught fatal signal 9

--- a/example/etc/log_ok.txt
+++ b/example/etc/log_ok.txt
@@ -1,6 +1,7 @@
-time:0.004
-time-wall:0.044
-max-rss:3196
-csw-voluntary:9
-csw-forced:6
+time:0.002
+time-wall:0.003
+max-rss:2900
+csw-voluntary:4
+csw-forced:1
+cg-mem:480
 exitcode:0

--- a/example/etc/log_re.txt
+++ b/example/etc/log_re.txt
@@ -1,8 +1,9 @@
 time:0.002
-time-wall:0.002
-max-rss:3056
-csw-voluntary:3
-csw-forced:3
+time-wall:0.003
+max-rss:2900
+csw-voluntary:4
+csw-forced:1
+cg-mem:460
 exitcode:1
 status:RE
 message:Exited with error status 1

--- a/example/etc/log_sg.txt
+++ b/example/etc/log_sg.txt
@@ -1,8 +1,9 @@
-time:0.002
-time-wall:0.134
-max-rss:3004
+time:0.006
+time-wall:0.116
+max-rss:2908
 csw-voluntary:5
 csw-forced:3
-exitsig:6
+cg-mem:448
+exitsig:11
 status:SG
-message:Caught fatal signal 6
+message:Caught fatal signal 11

--- a/example/etc/log_to.txt
+++ b/example/etc/log_to.txt
@@ -1,8 +1,9 @@
 status:TO
 message:Time limit exceeded
 killed:1
-time:2.095
+time:2.099
 time-wall:2.100
-max-rss:3076
+max-rss:844
 csw-voluntary:3
-csw-forced:93
+csw-forced:0
+cg-mem:448

--- a/example/scripts/compile_scripts/go
+++ b/example/scripts/compile_scripts/go
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+import os
+import subprocess
+import sys
+
+base_dir = sys.argv[1]
+compile_files = []
+for i in range(2, len(sys.argv)):
+    compile_files.append(sys.argv[i])
+
+output_path = os.path.join(base_dir, "bin")
+cmd = [
+    "/usr/bin/go", "build",
+    "-o", output_path, *compile_files,
+]
+
+capture = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+f = open(os.path.join(base_dir, "compileMsg"), "w")
+f.write(capture.stdout.decode("utf-8"))
+f.close()
+print(capture.returncode)
+print(output_path)

--- a/example/scripts/compile_scripts/java
+++ b/example/scripts/compile_scripts/java
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+import os
+import subprocess
+import sys
+import re
+
+base_dir = sys.argv[1]
+source_file = sys.argv[2]
+
+class_name = source_file.split("/")[-1].split(".")[0]
+lines = []
+with open(source_file, "r+") as file:
+    for line in file.readlines():
+        if re.match(r"[ \t]*public[ \t]+class[ \t]*", line):
+            lines.append("public class " + class_name + " {\n")
+        else:
+            lines.append(line)
+
+with open(source_file, "w+") as file:
+    file.writelines(lines)
+
+
+f = open(os.path.join(base_dir, "compileMsg"), "w")
+mkdir_capture = subprocess.run(
+    ['/bin/mkdir', os.path.join(base_dir, 'classes')],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT)
+
+f.write(mkdir_capture.stdout.decode("utf-8") + "\n")
+if mkdir_capture.returncode != 0:
+    print(1)
+    f.close()
+    sys.exit(0)
+
+javac_capture = subprocess.run(
+    ['/usr/lib/jvm/java-11-openjdk-amd64/bin/javac', '-d',
+     os.path.join(base_dir, 'classes'), source_file],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT)
+
+f.write(javac_capture.stdout.decode("utf-8") + "\n")
+if javac_capture.returncode != 0:
+    print(1)
+    f.close()
+    sys.exit(0)
+
+manifest = open(os.path.join(base_dir, "Manifest"), "w")
+manifest.write("Main-Class: "+ class_name + "\n")
+manifest.close()
+
+jar_capture = subprocess.run([
+    '/usr/bin/jar', 'cvmf',
+    os.path.join(base_dir, 'Manifest'),
+    os.path.join(base_dir, 'run.jar'), '-C',
+    os.path.join(base_dir, 'classes'), '.'
+],
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
+
+f.write(jar_capture.stdout.decode("utf-8") + "\n")
+if jar_capture.returncode != 0:
+    print(1)
+    f.close()
+    sys.exit(0)
+
+f.close()
+
+print(0)
+print(os.path.join(base_dir, 'run.jar'))

--- a/example/scripts/compile_scripts/java
+++ b/example/scripts/compile_scripts/java
@@ -32,8 +32,16 @@ if mkdir_capture.returncode != 0:
     f.close()
     sys.exit(0)
 
+javac_symlink = subprocess.run(["which", "javac"],
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT)
+
+javac_path = subprocess.run(["readlink", "-f", javac_symlink.stdout.decode("utf-8").strip()],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT).stdout.decode("utf-8").strip()
+
 javac_capture = subprocess.run(
-    ['/usr/lib/jvm/java-11-openjdk-amd64/bin/javac', '-d',
+    [javac_path, '-d',
      os.path.join(base_dir, 'classes'), source_file],
     stdout=subprocess.PIPE,
     stderr=subprocess.STDOUT)
@@ -45,7 +53,7 @@ if javac_capture.returncode != 0:
     sys.exit(0)
 
 manifest = open(os.path.join(base_dir, "Manifest"), "w")
-manifest.write("Main-Class: "+ class_name + "\n")
+manifest.write("Main-Class: " + class_name + "\n")
 manifest.close()
 
 jar_capture = subprocess.run([
@@ -54,8 +62,8 @@ jar_capture = subprocess.run([
     os.path.join(base_dir, 'run.jar'), '-C',
     os.path.join(base_dir, 'classes'), '.'
 ],
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT)
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT)
 
 f.write(jar_capture.stdout.decode("utf-8") + "\n")
 if jar_capture.returncode != 0:

--- a/example/scripts/config.yaml
+++ b/example/scripts/config.yaml
@@ -5,6 +5,10 @@ language:
     extension: "py"
   - id: "rust"
     extension: "rs"
+  - id: "go"
+    extension: "go"
+  - id: "java"
+    extension: "java"
 message:
   Correct: "Output is correct"
   Partially Correct: "Output is partially correct"

--- a/example/scripts/runner_scripts/go
+++ b/example/scripts/runner_scripts/go
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec -c ./bin

--- a/example/scripts/runner_scripts/java
+++ b/example/scripts/runner_scripts/java
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-JAVA_PATH=$(readlink -f `which javac`)
+JAVA_PATH=$(readlink -f `which java`)
 exec -c $JAVA_PATH -jar run.jar

--- a/example/scripts/runner_scripts/java
+++ b/example/scripts/runner_scripts/java
@@ -1,2 +1,3 @@
-#!/usr/bin/bash
-exec -c /usr/lib/jvm/java-11-openjdk-amd64/bin/java -jar run.jar
+#!/usr/bin/env bash
+JAVA_PATH=$(readlink -f `which javac`)
+exec -c $JAVA_PATH -jar run.jar

--- a/example/scripts/runner_scripts/java
+++ b/example/scripts/runner_scripts/java
@@ -1,0 +1,2 @@
+#!/usr/bin/bash
+exec -c /usr/lib/jvm/java-11-openjdk-amd64/bin/java -jar run.jar

--- a/grader/src/instance/mod.rs
+++ b/grader/src/instance/mod.rs
@@ -87,6 +87,7 @@ impl Instance {
     pub fn get_result(&self) -> InstanceResult {
         let log_content = fs::read_to_string(&self.log_file).unwrap();
         let mut result: InstanceResult = Default::default();
+        let mut memory_limit_exceeded = false;
         for log_line in log_content.lines() {
             let args: Vec<&str> = log_line.split(':').collect();
             if args.len() >= 2 {
@@ -102,11 +103,12 @@ impl Instance {
                     }
                     "time" => result.time_usage = args[1].parse().unwrap(),
                     "cg-mem" => result.memory_usage = args[1].parse().unwrap(),
+                    "cg-oom-killed" => memory_limit_exceeded = args[1].trim() == "1",
                     _ => (),
                 }
             }
         }
-        if result.memory_usage > self.memory_limit && result.status == Default::default() {
+        if memory_limit_exceeded || result.memory_usage >= self.memory_limit && result.status == Default::default() {
             result.status = RunVerdict::VerdictMLE;
         }
         result
@@ -144,6 +146,10 @@ impl Instance {
 
     pub fn run(&self) -> InstanceResult {
         let args = self.get_run_arguments();
+        for i in args.iter() {
+            print!("{} ", i);
+        }
+        println!();
         Command::new(get_env("ISOLATE_PATH"))
             .args(args)
             .output()

--- a/grader/src/instance/mod.rs
+++ b/grader/src/instance/mod.rs
@@ -73,14 +73,14 @@ impl Instance {
             "input",
             "-o",
             "output",
-            "--run",
-            "--",
-            "runner",
+            "--processes=128",
             "--cg",
             "--cg-timing",
-            "--processes=128",
             format!("--cg-mem={}", self.memory_limit),
-            format!("--dir={}", get_env("ALTERNATIVE_PATH"))
+            format!("--dir={}", get_env("ALTERNATIVE_PATH")),
+            "--run",
+            "--",
+            "runner"
         ]
     }
 
@@ -101,7 +101,7 @@ impl Instance {
                         }
                     }
                     "time" => result.time_usage = args[1].parse().unwrap(),
-                    "max-rss" => result.memory_usage = args[1].parse().unwrap(),
+                    "cg-mem" => result.memory_usage = args[1].parse().unwrap(),
                     _ => (),
                 }
             }

--- a/grader/src/instance/tests.rs
+++ b/grader/src/instance/tests.rs
@@ -107,8 +107,8 @@ fn should_read_log_correctly_when_ok() {
         result,
         InstanceResult {
             status: RunVerdict::VerdictOK,
-            time_usage: 0.004,
-            memory_usage: 3196,
+            time_usage: 0.002,
+            memory_usage: 480,
         }
     );
 }
@@ -133,7 +133,7 @@ fn should_trigger_when_read_log_with_re() {
         InstanceResult {
             status: RunVerdict::VerdictRE,
             time_usage: 0.002,
-            memory_usage: 3056,
+            memory_usage: 460,
         }
     );
 }
@@ -157,8 +157,8 @@ fn should_trigger_when_read_log_with_to() {
         result,
         InstanceResult {
             status: RunVerdict::VerdictTLE,
-            time_usage: 2.095,
-            memory_usage: 3076,
+            time_usage: 2.099,
+            memory_usage: 448,
         }
     );
 }
@@ -182,8 +182,8 @@ fn should_trigger_when_read_log_with_sg() {
         result,
         InstanceResult {
             status: RunVerdict::VerdictSG,
-            time_usage: 0.002,
-            memory_usage: 3004,
+            time_usage: 0.006,
+            memory_usage: 448,
         }
     );
 }
@@ -216,7 +216,7 @@ fn should_trigger_when_read_log_with_xx() {
 fn should_trigger_when_read_log_with_mle() {
     dotenv().ok();
 
-    let test_log = get_example_dir().join("etc").join("log_ok.txt");
+    let test_log = get_example_dir().join("etc").join("log_mle.txt");
     let tmp_log = get_tmp_path().join("test_log_mle.txt");
     fs::copy(&test_log, &tmp_log).unwrap();
 
@@ -231,8 +231,8 @@ fn should_trigger_when_read_log_with_mle() {
         result,
         InstanceResult {
             status: RunVerdict::VerdictMLE,
-            time_usage: 0.004,
-            memory_usage: 3196,
+            time_usage: 0.090,
+            memory_usage: 1000,
         }
     );
 }
@@ -313,11 +313,11 @@ fn should_get_mle() {
     let base_dir = get_example_dir().join("etc");
     let tmp_dir = TempDir::new("should_get_mle");
 
-    compile_cpp(&tmp_dir.0, &base_dir.join("a_plus_b.cpp"));
+    compile_cpp(&tmp_dir.0, &base_dir.join("a_plus_b_MLE.cpp"));
 
     let mut instance = instance! {
         time_limit: 1.0,
-        memory_limit: 1,
+        memory_limit: 32,
         bin_path: tmp_dir.0.join("bin"),
         input_path: get_example_dir().join("tasks").join("a_plus_b").join("testcases").join("1.in"),
         runner_path: get_example_dir().join("scripts").join("runner_scripts").join("cpp")

--- a/grader/src/submission/tests.rs
+++ b/grader/src/submission/tests.rs
@@ -424,3 +424,50 @@ fn should_run_rust_sg_skipped() {
     );
     assert_eq!(_result.group_result[1].run_result[1].status, s!(""));
 }
+
+
+#[test]
+fn should_compile_go_successfully() {
+    dotenv().ok();
+
+    let code = fs::read_to_string(get_example_dir().join("etc").join("a_plus_b.go")).unwrap();
+
+    let mut submission = Submission::from(s!("a_plus_b"), s!("000020"), s!("go"), &vec![code]);
+    submission.compile();
+}
+
+#[test]
+fn should_run_go_successfully() {
+    dotenv().ok();
+
+    let code = fs::read_to_string(get_example_dir().join("etc").join("a_plus_b.go")).unwrap();
+
+    let mut submission = Submission::from(s!("a_plus_b"), s!("000021"), s!("go"), &vec![code]);
+    submission.compile();
+
+    let _result = submission.run();
+    assert_eq!(_result.score, 100.0);
+}
+
+#[test]
+fn should_compile_java_successfully() {
+    dotenv().ok();
+
+    let code = fs::read_to_string(get_example_dir().join("etc").join("a_plus_b.java")).unwrap();
+
+    let mut submission = Submission::from(s!("a_plus_b"), s!("000022"), s!("java"), &vec![code]);
+    submission.compile();
+}
+
+#[test]
+fn should_run_java_successfully() {
+    dotenv().ok();
+
+    let code = fs::read_to_string(get_example_dir().join("etc").join("a_plus_b.java")).unwrap();
+
+    let mut submission = Submission::from(s!("a_plus_b"), s!("000023"), s!("java"), &vec![code]);
+    submission.compile();
+
+    let _result = submission.run();
+    assert_eq!(_result.score, 100.0);
+}

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ git -C ${SCRIPTPATH} submodule update --init --recursive --depth 1
 
 echo "${green}Setting up compilers and dependencies${normal}"
 sudo apt-get update -y
-sudo apt-get install --no-install-recommends -y build-essential cargo openjdk-17-jdk libcap-dev sysfsutils
+sudo apt-get install --no-install-recommends -y build-essential cargo openjdk-17-jdk libcap-dev sysfsutils golang
 
 echo "Setting up isolate..."
 echo 0 > /proc/sys/kernel/randomize_va_space


### PR DESCRIPTION
- Read memory usage properly from `cg-mem`
- Fix arguments not properly called resulting in process limitation
- Fix instance testcases to read memory usage from `cg-mem` as well
- Add support for go
- Add support for java